### PR TITLE
removed vec3 rotation based on rot matrices

### DIFF
--- a/lobster_common/quaternion.py
+++ b/lobster_common/quaternion.py
@@ -28,15 +28,19 @@ class Quaternion:
         if isinstance(data, Quaternion):
             data = data.numpy().copy()
 
-        numpy_data: np.ndarray = np.asarray(data)
+        self._data: np.ndarray = np.asarray(data)
 
-        if numpy_data.shape[0] != 4:
+        if self._data.shape[0] != 4:
             raise InputDimensionError("A Quaternion needs an input array of length 4")
-
-        self._data: np.ndarray = numpy_data / np.linalg.norm(numpy_data)
 
     def numpy(self) -> np.ndarray:
         return self._data
+
+    def normalized(self):
+        return Quaternion(self.numpy() / self.magnitude())
+
+    def magnitude(self):
+        return np.linalg.norm(self._data)
 
     @property
     def x(self) -> float:
@@ -95,7 +99,6 @@ class Quaternion:
         :return: 3x3 rotation matrix.
         """
         n = np.linalg.norm(self.numpy())
-
         if n == 0.0:
             raise ZeroDivisionError(f"Input to `as_rotation_matrix({self})` has zero norm")
 

--- a/lobster_common/vec3.py
+++ b/lobster_common/vec3.py
@@ -53,18 +53,20 @@ class Vec3:
     def rotate(self, quaternion: quaternion.Quaternion) -> 'Vec3':
         """
         Rotates the vector by the given quaternion.
+        Use this method to rotate a vector from the body frame to the world frame
         :param quaternion: Rotation
         :return: Rotated vector
         """
-        return Vec3(quaternion.get_rotation_matrix().dot(self._data))
+        return Vec3((quaternion * [self.x, self.y, self.z, 0.0] * quaternion.conjugate()).numpy()[0:3])
 
     def rotate_inverse(self, quaternion: quaternion.Quaternion) -> 'Vec3':
         """
         Inversely rotates the vector by the given quaternion.
+        Use this method to rotate a vector from the world frame to the body frame
         :param quaternion: Rotation
         :return: Rotated vector
         """
-        return Vec3(quaternion.get_inverse_rotation_matrix().dot(self._data))
+        return Vec3((quaternion.conjugate() * [self.x, self.y, self.z, 0.0] * quaternion).numpy()[0:3])
 
     def __add__(self, other):
         if isinstance(other, Vec3):

--- a/test/test_quaternion.py
+++ b/test/test_quaternion.py
@@ -34,7 +34,7 @@ class QuaternionTest(unittest.TestCase):
     def test_from_matrix(self):
         np.random.seed(0)
         for _ in range(100):
-            q = quaternion.Quaternion(np.random.rand(4))
+            q = quaternion.Quaternion(np.random.rand(4)).normalized()
 
             matrix = q.get_rotation_matrix()
 
@@ -55,7 +55,7 @@ class QuaternionTest(unittest.TestCase):
 
         for _ in range(100):
             q_np = np.random.rand(4)
-            q2_np = q_np * np.array([1 + 10e-5, 1 + 10e-5, 1 + 10e-5, 1 + 10e-5])
+            q2_np = q_np * np.array([1 + 10e-6, 1 + 10e-6, 1 + 10e-6, 1 + 10e-6])
 
             q1 = quaternion.Quaternion(q_np)
             q2 = quaternion.Quaternion(q2_np)

--- a/test/test_vec3.py
+++ b/test/test_vec3.py
@@ -19,7 +19,10 @@ class Vec3Test(unittest.TestCase):
             rotation = quaternion.Quaternion.from_euler(vec3.Vec3(np.random.rand(3) * 4 * math.pi - 2 * math.pi))
 
             numpy_method = vec3.Vec3(rotation.get_rotation_matrix().dot(vec.numpy()))
-
             rotate_method = vec.rotate(rotation)
 
-            self.assertEqual(numpy_method, rotate_method)
+            numpy_method_inv = vec3.Vec3(rotation.get_inverse_rotation_matrix().dot(vec.numpy()))
+            rotate_method_inv = vec.rotate_inverse(rotation)
+
+            self.assertTrue(np.linalg.norm((numpy_method - rotate_method).numpy()) < 0.00000000001)
+            self.assertTrue(np.linalg.norm((numpy_method_inv - rotate_method_inv).numpy()) < 0.00000000001)

--- a/test/test_vec3.py
+++ b/test/test_vec3.py
@@ -24,5 +24,5 @@ class Vec3Test(unittest.TestCase):
             numpy_method_inv = vec3.Vec3(rotation.get_inverse_rotation_matrix().dot(vec.numpy()))
             rotate_method_inv = vec.rotate_inverse(rotation)
 
-            self.assertTrue(np.linalg.norm((numpy_method - rotate_method).numpy()) < 0.00000000001)
-            self.assertTrue(np.linalg.norm((numpy_method_inv - rotate_method_inv).numpy()) < 0.00000000001)
+            self.assertTrue(np.allclose(numpy_method.numpy(), rotate_method.numpy()))
+            self.assertTrue(np.allclose(numpy_method_inv.numpy(), rotate_method_inv.numpy()))


### PR DESCRIPTION
The main advantage is that the inverse rotation does not utilize a matrix inversion.
Therefore the inverse_rotation used to take 5 times as long as the rotate method.
With this fix both the rotation and the inverse_rotation use exactly the same math.